### PR TITLE
Remove XML functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pandoc Plugin
 
-This is a plugin for [Janeway](https://github.com/BirkbeckCTP/janeway) that provides a button for typesetters to automatically generate html or xml files from user article submissions in docx/rtf. These files are first converted to markdown, and from there to html or xml, and then registered as galleys of the original article.
+This is a plugin for [Janeway](https://github.com/BirkbeckCTP/janeway) that provides a button for typesetters to automatically generate html files from user article submissions in docx/rtf. These files are first converted to markdown, and from there to html, and then registered as galleys of the original article.
 
 ## How to install:
 

--- a/hooks.py
+++ b/hooks.py
@@ -6,7 +6,7 @@ from utils import models, setting_handler
 
 def inject_pandoc(context):
     """
-    Provides buttons for users to automatically convert manuscript files (docx or rtf) to html or xml.
+    Provides buttons for users to automatically convert manuscript files (docx or rtf) to html.
     Uses the pandoc plugin, which must be installed on the server.
     """
     plugin = models.Plugin.objects.get(name=plugin_settings.SHORT_NAME)

--- a/plugin_settings.py
+++ b/plugin_settings.py
@@ -1,7 +1,7 @@
 from utils import models
 
 PLUGIN_NAME = 'Pandoc Plugin'
-DESCRIPTION = 'A plugin to assist typesetters with converting docx/rtf files to html or xml'
+DESCRIPTION = 'A plugin to assist typesetters with converting docx/rtf files to html'
 AUTHOR = 'Drew Stimson and Daniel Evans'
 VERSION = 0.1
 SHORT_NAME = 'pandoc_plugin'

--- a/templates/pandoc_plugin/inject.html
+++ b/templates/pandoc_plugin/inject.html
@@ -2,6 +2,5 @@
   <form action="{% url 'pandoc_convert' article.pk file.pk %}" method="post">
     {% csrf_token %}
     <button type="submit" class="button success small" name="convert_html" value="{{ article.pk }}">Generate HTML</button>
-    <button type="submit" class="button success small" name="convert_xml" value="{{ article.pk }}">Generate XML</button>
   </form>
 </div>

--- a/views.py
+++ b/views.py
@@ -53,7 +53,7 @@ def convert(request, article_id=None, file_id=None):
     memory_limit = ['+RTS', '-M512M', '-RTS']
     base_pandoc_command = ['pandoc'] + memory_limit
 
-    # if post, get the original manuscript file, convert to html or xml based on which button the user clicked
+    # if post, get the original manuscript file, convert to html
     if request.method == "POST":
 
         # retrieve article and selected manuscript
@@ -79,7 +79,7 @@ def convert(request, article_id=None, file_id=None):
 
         #logic.save_galley(article, request, temp_md_path, True, "Other", True, save_to_disk=False)
 
-        # convert to html or xml, passing article's title as metadata
+        # convert to html, passing article's title as metadata
         metadata = '--metadata=title:"{}"'.format(article.title)
 
         if request.POST.get('convert_html'):
@@ -89,13 +89,6 @@ def convert(request, article_id=None, file_id=None):
             subprocess.run(pandoc_command, stderr=subprocess.PIPE, check=True)
             logic.save_galley(article, request, output_path, True, 'HTML', False, save_to_disk=False)
 
-        elif request.POST.get('convert_xml'):
-
-            output_path = stripped_path + '.xml'
-            pandoc_command = base_pandoc_command + ['-s', temp_md_path, '-o', output_path, metadata]
-            subprocess.run(pandoc_command, stderr=subprocess.PIPE, check=True)
-            logic.save_galley(article, request, output_path, True, 'XML', False, save_to_disk=False)
-
             # TODO: make new file child of manuscript file
 
         return redirect(reverse('production_article', kwargs={'article_id': article.pk}))
@@ -104,4 +97,4 @@ def convert(request, article_id=None, file_id=None):
     else:
         return reverse('production_article', kwargs={'article_id': request.article.pk})
 
-# NEED LOGIC FOR IF HTML OR XML ALREADY GENERATED
+# NEED LOGIC FOR IF HTML ALREADY GENERATED


### PR DESCRIPTION
Closes #2

This removes the XML-production code from views.py.
This also removes buttons from the plugin forms, and
revises documentation appropriately.