### PR TITLE
explicit encoding utf8 with open

### DIFF
--- a/views.py
+++ b/views.py
@@ -94,7 +94,7 @@ def convert(request, article_id=None, file_id=None):
                 del img["style"]
 
             # Write revised HTML to file
-            with open(output_path, "w") as html_file:
+            with open(output_path, mode="w", encoding="utf-8") as html_file:
                 print(pandoc_soup.prettify(), file=html_file)
 
             logic.save_galley(article, request, output_path, True, 'HTML', False, save_to_disk=False)


### PR DESCRIPTION
I was consistently having a problem with bs4 trying to read the file that was opened at this line as ascii on the sandbox server of for CMU's janeway instance.
![image](https://user-images.githubusercontent.com/1020384/53748343-2b4ae300-3e73-11e9-8e7e-460a5332cfc1.png)
Adding .encoding("utf-8") to the `prettify()` function was injecting `\n` through the document.
Unfortunately, I was unable to recreate the same bug on my local but this line is just being more explicit.