### PR TITLE
Do not use pandoc's metadata feature

### DIFF
--- a/views.py
+++ b/views.py
@@ -73,11 +73,9 @@ def convert(request, article_id=None, file_id=None):
 
         if request.POST.get('convert_html'):
 
-            # convert to html, passing article's title as metadata
-            metadata = '--metadata=title:"{}"'.format(article.title)
             output_path = stripped_path + '.html'
 
-            pandoc_command = base_pandoc_command + ['-s', orig_path, '-t', 'html', metadata]
+            pandoc_command = base_pandoc_command + ['-s', orig_path, '-t', 'html']
 
             try:
                 pandoc_return = subprocess.run(pandoc_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)


### PR DESCRIPTION
When writing out a standalone HTML document, pando injects the title of the article into the html content as an `h1` tag. Janeway templates already handle the display of the article title, so we should prevent this pandoc behavior.

(I think in an ideal future, we'd write up a custom Janeway-friendly HTML pandoc template that would embed the metadata but suppress the title - but at the moment we really need the title to not show up! Also I'd want to know how future in-Janeway HTML editing would happen before speccing out a special pandoc template)