### PR TITLE
don't prettify output html

### DIFF
--- a/views.py
+++ b/views.py
@@ -93,7 +93,7 @@ def convert(request, article_id=None, file_id=None):
 
             # Write revised HTML to file
             with open(output_path, mode="w", encoding="utf-8") as html_file:
-                print(pandoc_soup.prettify(), file=html_file)
+                print(pandoc_soup, file=html_file)
 
             logic.save_galley(article, request, output_path, True, 'HTML', False, save_to_disk=False)
 


### PR DESCRIPTION
When BS prettifies html, it puts in a lot of line breaks - this is great for humans to read, but it actually changes the way that the HTML renders, specifically by adding space in between the end of a sentence and the footnote number:

```html
<p>
   That origin story appears to have arisen from a 1971 sociology paper, “Patterns of Evaluation in Science: Institutionalization, Structure and Functions of the Referee System” by Harriet Zuckerman and Robert Merton.
   <a class="footnote-ref" href="#fn1" id="fnref1">
    <sup>
     1
    </sup>
   </a>
<p>
```

This is bad because it actually changes the markup from what pandoc intended. So we won't prettify the html.

Closes https://github.com/dSHARP-CMU/cmesh-dev/issues/295